### PR TITLE
MinGW32/64 support

### DIFF
--- a/source.cpp
+++ b/source.cpp
@@ -27,7 +27,7 @@
 #include <assert.h>
 #include "clunk_assert.h"
 
-#if defined _MSC_VER || __APPLE__ || __FreeBSD__
+#if defined _MSC_VER || __APPLE__ || __FreeBSD__ || __MINGW32__
 #	define pow10f(x) powf(10.0f, (x))
 #	define log2f(x) (logf(x) / M_LN2)
 #endif


### PR DESCRIPTION
This pull request fixes compilation errors on win32/win64 with MinGW compiler.
```
C:/prefix/vangers/src/clunk/source.cpp: In static member function 'static void clunk::Source::idt_iit(const clunk::v3<float>&, const clunk::v3<float>&, float&, float&, float&)':
C:/prefix/vangers/src/clunk/source.cpp:102:22: error: 'pow10f' was not declared in this scope
  left_to_right_amp = pow10f(-sin(idt_angle));
                      ^~~~~~
C:/prefix/vangers/src/clunk/source.cpp:102:22: note: suggested alternative: 'powf'
  left_to_right_amp = pow10f(-sin(idt_angle));
                      ^~~~~~
                      powf
C:/prefix/vangers/src/clunk/source.cpp: In member function 'void clunk::Source::hrtf(int, unsigned int, clunk::Buffer&, const Sint16*, int, int, int, const float (* const&)[2][512], int, float)':
C:/prefix/vangers/src/clunk/source.cpp:160:13: error: 'pow10f' was not declared in this scope
   float m = pow10f(-kemar_data[kemar_idx][0][kemar_angle_idx] * v / 20) / decay;
             ^~~~~~
C:/prefix/vangers/src/clunk/source.cpp:160:13: note: suggested alternative: 'powf'
   float m = pow10f(-kemar_data[kemar_idx][0][kemar_angle_idx] * v / 20) / decay;
             ^~~~~~
             powf
make[2]: *** [CMakeFiles/clunk.dir/build.make:279: CMakeFiles/clunk.dir/source.cpp.obj] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:68: CMakeFiles/clunk.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```

It seems that `pow10f` is not defined by default - so we can add it to `#if defined` macro check in source.cpp: https://github.com/stalkerg/clunk/blob/445df298bb899c8da244211a374fd838bc12a8cf/source.cpp#L30-L33 I added only `__MINGW32__`, but it should work on mingw64 too because 64 bit version defines both `__MINGW32__` and `__MINGW64__`
  
  