### PR TITLE
Use SDL_OpenAudioDevice for audio output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
 project(clunk)
-cmake_minimum_required(VERSION 3.9)
 set(CMAKE_USE_RELATIVE_PATHS TRUE)
 include(CheckCXXSymbolExists)
 
@@ -39,6 +39,7 @@ set(SOURCES
 	context.cpp
 	distance_model.cpp
 	kemar.c
+	locker.cpp
 	logger.cpp
 	object.cpp
 	sample.cpp

--- a/clunk_c.cpp
+++ b/clunk_c.cpp
@@ -19,6 +19,7 @@
 */
 
 #include "context.h"
+#include "locker.h"
 #include "source.h"
 #include "stream.h"
 
@@ -455,12 +456,12 @@ CLUNKCAPI void clunk_buffer_pop(clunk_buffer *buffer, size_t n)
 
 CLUNKCAPI void clunk_audio_lock(void)
 {
-	SDL_LockAudio();
+	clunk::lock_audio();
 }
 
 CLUNKCAPI void clunk_audio_unlock(void)
 {
-	SDL_UnlockAudio();
+	clunk::unlock_audio();
 }
 
 CLUNKCAPI clunk_distance_model *clunk_distance_model_create(clunk_distance_model_type type, int clamped, float max_distance)

--- a/context.cpp
+++ b/context.cpp
@@ -36,7 +36,7 @@
 
 using namespace clunk;
 
-Context::Context() : period_size(0), listener(NULL), max_sources(8), fx_volume(1), distance_model(DistanceModel::Inverse, true, 128), fdump(NULL) {
+Context::Context() : device_id(0), period_size(0), listener(NULL), max_sources(8), fx_volume(1), distance_model(DistanceModel::Inverse, true, 128), fdump(NULL) {
 }
 
 void Context::callback(void *userdata, Uint8 *bstream, int len) {
@@ -148,7 +148,7 @@ void Context::process(Sint16 *stream, int size) {
 			buf_size = size;
 
 		int sdl_v = (int)floor(SDL_MIX_MAXVOLUME * stream_info.gain + 0.5f);
-		SDL_MixAudio((Uint8 *)stream, (Uint8 *)stream_info.buffer.get_ptr(), buf_size, sdl_v);
+		SDL_MixAudioFormat((Uint8 *)stream, (Uint8 *)stream_info.buffer.get_ptr(), spec.format, buf_size, sdl_v);
 		
 		if ((int)stream_info.buffer.get_size() > size) {
 			memmove(stream_info.buffer.get_ptr(), ((Uint8 *)stream_info.buffer.get_ptr()) + size, stream_info.buffer.get_size() - size);
@@ -187,7 +187,7 @@ void Context::process(Sint16 *stream, int size) {
 		if (sdl_v > SDL_MIX_MAXVOLUME)
 			sdl_v = SDL_MIX_MAXVOLUME;
 		
-		SDL_MixAudio((Uint8 *)stream, (Uint8 *)buf.get_ptr(), size, sdl_v);
+		SDL_MixAudioFormat((Uint8 *)stream, (Uint8 *)buf.get_ptr(), spec.format, size, sdl_v);
 	}
 	
 	if (fdump != NULL) {
@@ -228,6 +228,11 @@ void Context::init(const int sample_rate, const Uint8 channels, int period_size)
 		if (SDL_InitSubSystem(SDL_INIT_AUDIO) == -1)
 			throw_sdl(("SDL_InitSubSystem"));
 	}
+
+	if (get_audio_device_id() != 0)
+		throw_ex(("audio device is already opened"));
+	if (channels > 2)
+		throw_ex(("Clunk requires mono or stereo output, got %d channels", channels));
 	
 	SDL_AudioSpec src;
 	memset(&src, 0, sizeof(src));
@@ -240,18 +245,33 @@ void Context::init(const int sample_rate, const Uint8 channels, int period_size)
 	
 	this->period_size = period_size;
 	
-	if ( SDL_OpenAudio(&src, &spec) < 0 )
-		throw_sdl(("SDL_OpenAudio(%d, %u, %d)", sample_rate, channels, period_size));
-	if (spec.format != AUDIO_S16SYS)
-		throw_ex(("SDL_OpenAudio(%d, %u, %d) returned format %d", sample_rate, channels, period_size, spec.format));
+	device_id = SDL_OpenAudioDevice(NULL, 0, &src, &spec, 0);
+	if (device_id == 0)
+		throw_sdl(("SDL_OpenAudioDevice(%d, %u, %d)", sample_rate, channels, period_size));
+	if (spec.format != AUDIO_S16SYS) {
+		Uint16 opened_format = spec.format;
+		SDL_AudioDeviceID opened_device_id = device_id;
+		device_id = 0;
+		SDL_CloseAudioDevice(opened_device_id);
+		throw_ex(("SDL_OpenAudioDevice(%d, %u, %d) returned format %d", sample_rate, channels, period_size, opened_format));
+	}
 	if (spec.channels < 2)
 		LOG_ERROR(("Could not operate on %d channels", spec.channels));
+	else if (spec.channels > 2) {
+		Uint8 opened_channels = spec.channels;
+		SDL_AudioDeviceID opened_device_id = device_id;
+		device_id = 0;
+		SDL_CloseAudioDevice(opened_device_id);
+		throw_ex(("Clunk requires mono or stereo output, got %d channels", opened_channels));
+	}
 
-	LOG_DEBUG(("opened audio device, sample rate: %d, period: %d, channels: %d", spec.freq, spec.samples, spec.channels));
-	SDL_PauseAudio(0);
-	
-	AudioLocker l;
-	listener = create_object();
+	set_audio_device_id(device_id);
+	LOG_DEBUG(("opened audio device %u, sample rate: %d, period: %d, channels: %d", (unsigned)device_id, spec.freq, spec.samples, spec.channels));
+	{
+		AudioLocker l;
+		listener = create_object();
+	}
+	SDL_PauseAudioDevice(device_id, 0);
 }
 
 void Context::delete_object(Object *o) {
@@ -266,10 +286,23 @@ void Context::deinit() {
 	if (!SDL_WasInit(SDL_INIT_AUDIO))
 		return;
 	
-	AudioLocker l;
-	delete listener;
-	listener = NULL;
-	SDL_CloseAudio();
+	SDL_AudioDeviceID opened_device_id = device_id;
+	if (opened_device_id != 0) {
+		SDL_PauseAudioDevice(opened_device_id, 1);
+		AudioLocker l(opened_device_id);
+		delete listener;
+		listener = NULL;
+	} else {
+		delete listener;
+		listener = NULL;
+	}
+
+	if (opened_device_id != 0) {
+		if (get_audio_device_id() == opened_device_id)
+			set_audio_device_id(0);
+		SDL_CloseAudioDevice(opened_device_id);
+		device_id = 0;
+	}
 	
 	if (fdump != NULL) {
 		fclose(fdump);

--- a/context.h
+++ b/context.h
@@ -137,6 +137,7 @@ public:
 
 private: 
 	SDL_AudioSpec spec;
+	SDL_AudioDeviceID device_id;
 	int period_size;
 
 	static void callback(void *userdata, Uint8 *stream, int len);
@@ -186,4 +187,3 @@ private:
 
 
 #endif
-

--- a/locker.cpp
+++ b/locker.cpp
@@ -1,0 +1,58 @@
+/* libClunk - cross-platform 3D audio API built on top SDL library
+ * Copyright (C) 2007-2008 Netive Media Group
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "locker.h"
+
+namespace {
+	SDL_AudioDeviceID current_audio_device_id = 0;
+}
+
+SDL_AudioDeviceID clunk::get_audio_device_id() {
+	return current_audio_device_id;
+}
+
+void clunk::set_audio_device_id(SDL_AudioDeviceID device_id) {
+	current_audio_device_id = device_id;
+}
+
+void clunk::lock_audio() {
+	SDL_AudioDeviceID device_id = get_audio_device_id();
+	if (device_id != 0)
+		SDL_LockAudioDevice(device_id);
+}
+
+void clunk::unlock_audio() {
+	SDL_AudioDeviceID device_id = get_audio_device_id();
+	if (device_id != 0)
+		SDL_UnlockAudioDevice(device_id);
+}
+
+clunk::AudioLocker::AudioLocker() : device_id(get_audio_device_id()) {
+	if (device_id != 0)
+		SDL_LockAudioDevice(device_id);
+}
+
+clunk::AudioLocker::AudioLocker(SDL_AudioDeviceID device_id) : device_id(device_id) {
+	if (device_id != 0)
+		SDL_LockAudioDevice(device_id);
+}
+
+clunk::AudioLocker::~AudioLocker() {
+	if (device_id != 0)
+		SDL_UnlockAudioDevice(device_id);
+}

--- a/locker.h
+++ b/locker.h
@@ -31,16 +31,20 @@ namespace clunk {
 
 struct CLUNKAPI AudioLocker {
 	///locks audio 
-	AudioLocker () {
-		SDL_LockAudio();
-	}
+	AudioLocker();
+	explicit AudioLocker(SDL_AudioDeviceID device_id);
 	///unlocks audio 
-	~AudioLocker() {
-		SDL_UnlockAudio();
-	}
+	~AudioLocker();
+
+private:
+	SDL_AudioDeviceID device_id;
 };
+
+SDL_AudioDeviceID CLUNKAPI get_audio_device_id();
+void CLUNKAPI set_audio_device_id(SDL_AudioDeviceID device_id);
+void CLUNKAPI lock_audio();
+void CLUNKAPI unlock_audio();
 }
 
 
 #endif
-


### PR DESCRIPTION
## Summary

This refactors Clunk audio output from the legacy `SDL_OpenAudio` API to the SDL2 `SDL_OpenAudioDevice` API.

This is a broader and more explicit solution to the issue discussed in #4. PR #4 correctly avoids receiving an unexpected callback format by passing `obtained == NULL` to `SDL_OpenAudio`; switching to `SDL_OpenAudioDevice(..., allowed_changes = 0)` solves the same problem through SDL2's preferred device API while keeping Clunk's callback format fixed to `AUDIO_S16SYS`.

Changes included:

- Replace `SDL_OpenAudio` / `SDL_PauseAudio` / `SDL_CloseAudio` with device-specific `SDL_OpenAudioDevice` / `SDL_PauseAudioDevice` / `SDL_CloseAudioDevice`.
- Track the opened `SDL_AudioDeviceID` for lifecycle management.
- Move `AudioLocker` to device-specific locking via `SDL_LockAudioDevice` / `SDL_UnlockAudioDevice`.
- Replace legacy `SDL_MixAudio` with `SDL_MixAudioFormat`, because `SDL_MixAudio` is tied to legacy device id 1.
- Reject unsupported output channel counts before opening the device.
- Create the listener before unpausing the device, so the callback cannot run with a null listener.
- Move `cmake_minimum_required()` before `project()` and bump it to 3.10 to avoid current CMake developer/deprecation warnings.

## Checks

- `cmake -S . -B /tmp/clunk-build-pr5 -Wdev`
- `cmake --build /tmp/clunk-build-pr5`
- `ctest --test-dir /tmp/clunk-build-pr5 --output-on-failure` (no tests found)
- Local SDL dummy-driver smoke test for valid init, invalid `channels = 3`, and re-init after failure.
